### PR TITLE
Move error handling into _win32api

### DIFF
--- a/ezconsole/abstract/_win32api.py
+++ b/ezconsole/abstract/_win32api.py
@@ -59,7 +59,7 @@ class Win32APIError(Exception):
     pass
 
 
-def _check_handle(result, func, _) -> int:
+def _errcheck_return_handle(result, func, _) -> int:
 
     if result == INVALID_HANDLE_VALUE.value:
         raise Win32APIError(f"{func.__name__}() failed")
@@ -67,7 +67,7 @@ def _check_handle(result, func, _) -> int:
     return result
 
 
-def _check_success(result, func, _) -> None:
+def _errcheck_return_success(result, func, _) -> None:
 
     if not result:
         raise Win32APIError(f"{func.__name__}() failed")
@@ -81,45 +81,45 @@ GetStdHandle.argtypes = [
     DWORD,
 ]
 GetStdHandle.restype = HANDLE
-GetStdHandle.errcheck = _check_handle
+GetStdHandle.errcheck = _errcheck_return_handle
 
 FillConsoleOutputCharacterW = _windll.kernel32.FillConsoleOutputCharacterW
 FillConsoleOutputCharacterW.argtypes = [HANDLE, WCHAR, DWORD, COORD, LPDWORD]
 FillConsoleOutputCharacterW.restype = BOOL
-FillConsoleOutputCharacterW.errcheck = _check_success
+FillConsoleOutputCharacterW.errcheck = _errcheck_return_success
 
 GetConsoleMode = _windll.kernel32.GetConsoleMode
 GetConsoleMode.argtypes = [HANDLE, LPDWORD]
 GetConsoleMode.restype = BOOL
-GetConsoleMode.errcheck = _check_success
+GetConsoleMode.errcheck = _errcheck_return_success
 
 GetConsoleScreenBufferInfo = _windll.kernel32.GetConsoleScreenBufferInfo
 GetConsoleScreenBufferInfo.argtypes = [HANDLE, _POINTER(ConsoleScreenBufferInfo)]
 GetConsoleScreenBufferInfo.restype = BOOL
-GetConsoleScreenBufferInfo.errcheck = _check_success
+GetConsoleScreenBufferInfo.errcheck = _errcheck_return_success
 
 ScrollConsoleScreenBufferW = _windll.kernel32.ScrollConsoleScreenBufferW
 ScrollConsoleScreenBufferW.argtypes = [HANDLE, PSMALL_RECT, PSMALL_RECT, COORD,
                                        _POINTER(CharInfo)]
 ScrollConsoleScreenBufferW.restype = BOOL
-ScrollConsoleScreenBufferW.errcheck = _check_success
+ScrollConsoleScreenBufferW.errcheck = _errcheck_return_success
 
 SetConsoleCursorPosition = _windll.kernel32.SetConsoleCursorPosition
 SetConsoleCursorPosition.argtypes = [HANDLE, COORD]
 SetConsoleCursorPosition.restype = BOOL
-SetConsoleCursorPosition.errcheck = _check_success
+SetConsoleCursorPosition.errcheck = _errcheck_return_success
 
 SetConsoleMode = _windll.kernel32.SetConsoleMode
 SetConsoleMode.argtypes = [HANDLE, DWORD]
 SetConsoleMode.restype = BOOL
-SetConsoleMode.errcheck = _check_success
+SetConsoleMode.errcheck = _errcheck_return_success
 
 WriteConsoleW = _windll.kernel32.WriteConsoleW
 WriteConsoleW.argtypes = [HANDLE, LPWSTR, DWORD, LPDWORD, LPVOID]
 WriteConsoleW.restype = BOOL
-WriteConsoleW.errcheck = _check_success
+WriteConsoleW.errcheck = _errcheck_return_success
 
 WriteConsoleOutputCharacterW = _windll.kernel32.WriteConsoleOutputCharacterW
 WriteConsoleOutputCharacterW.argtypes = [HANDLE, LPCWSTR, DWORD, COORD, LPDWORD]
 WriteConsoleOutputCharacterW.restype = BOOL
-WriteConsoleOutputCharacterW.errcheck = _check_success
+WriteConsoleOutputCharacterW.errcheck = _errcheck_return_success

--- a/ezconsole/abstract/_win32api.py
+++ b/ezconsole/abstract/_win32api.py
@@ -55,6 +55,24 @@ class ConsoleScreenBufferInfo(_Structure):
 INVALID_HANDLE_VALUE = HANDLE(-1)
 
 
+class Win32APIError(Exception):
+    pass
+
+
+def _check_handle(result, func, _) -> int:
+
+    if result == INVALID_HANDLE_VALUE.value:
+        raise Win32APIError(f"{func.__name__}() failed")
+
+    return result
+
+
+def _check_success(result, func, _) -> None:
+
+    if not result:
+        raise Win32APIError(f"{func.__name__}() failed")
+
+
 _windll = _LibraryLoader(_WinDLL)
 
 
@@ -63,36 +81,45 @@ GetStdHandle.argtypes = [
     DWORD,
 ]
 GetStdHandle.restype = HANDLE
+GetStdHandle.errcheck = _check_handle
 
 FillConsoleOutputCharacterW = _windll.kernel32.FillConsoleOutputCharacterW
 FillConsoleOutputCharacterW.argtypes = [HANDLE, WCHAR, DWORD, COORD, LPDWORD]
 FillConsoleOutputCharacterW.restype = BOOL
+FillConsoleOutputCharacterW.errcheck = _check_success
 
 GetConsoleMode = _windll.kernel32.GetConsoleMode
 GetConsoleMode.argtypes = [HANDLE, LPDWORD]
 GetConsoleMode.restype = BOOL
+GetConsoleMode.errcheck = _check_success
 
 GetConsoleScreenBufferInfo = _windll.kernel32.GetConsoleScreenBufferInfo
 GetConsoleScreenBufferInfo.argtypes = [HANDLE, _POINTER(ConsoleScreenBufferInfo)]
 GetConsoleScreenBufferInfo.restype = BOOL
+GetConsoleScreenBufferInfo.errcheck = _check_success
 
 ScrollConsoleScreenBufferW = _windll.kernel32.ScrollConsoleScreenBufferW
 ScrollConsoleScreenBufferW.argtypes = [HANDLE, PSMALL_RECT, PSMALL_RECT, COORD,
                                        _POINTER(CharInfo)]
 ScrollConsoleScreenBufferW.restype = BOOL
+ScrollConsoleScreenBufferW.errcheck = _check_success
 
 SetConsoleCursorPosition = _windll.kernel32.SetConsoleCursorPosition
 SetConsoleCursorPosition.argtypes = [HANDLE, COORD]
 SetConsoleCursorPosition.restype = BOOL
+SetConsoleCursorPosition.errcheck = _check_success
 
 SetConsoleMode = _windll.kernel32.SetConsoleMode
 SetConsoleMode.argtypes = [HANDLE, DWORD]
 SetConsoleMode.restype = BOOL
+SetConsoleMode.errcheck = _check_success
 
 WriteConsoleW = _windll.kernel32.WriteConsoleW
 WriteConsoleW.argtypes = [HANDLE, LPWSTR, DWORD, LPDWORD, LPVOID]
 WriteConsoleW.restype = BOOL
+WriteConsoleW.errcheck = _check_success
 
 WriteConsoleOutputCharacterW = _windll.kernel32.WriteConsoleOutputCharacterW
 WriteConsoleOutputCharacterW.argtypes = [HANDLE, LPCWSTR, DWORD, COORD, LPDWORD]
 WriteConsoleOutputCharacterW.restype = BOOL
+WriteConsoleOutputCharacterW.errcheck = _check_success


### PR DESCRIPTION
Relieve the callers in the win32 module from doing the Win32 return code checking and exception raising.